### PR TITLE
[NMOD-7673] Use LSID and ASN (instead of node name) for BGP-LS node key

### DIFF
--- a/build/unicastv4-bgp/test_bed.yml
+++ b/build/unicastv4-bgp/test_bed.yml
@@ -20,7 +20,7 @@ networks:
 
 services:
   zoo:
-    image: bitnami/zookeeper:latest
+    image: bitnamilegacy/zookeeper:latest
     hostname: zoo
     container_name: zoo
     ports:
@@ -35,7 +35,7 @@ services:
         ipv4_address: 10.1.1.5
 
   kafka:
-    image: bitnami/kafka:2.6.0
+    image: bitnamilegacy/kafka:2.6.0
     hostname: kafka
     container_name: kafka
     ports:

--- a/pkg/store/bgpls.go
+++ b/pkg/store/bgpls.go
@@ -7,10 +7,12 @@ import (
 	"github.com/sbezverk/gobmp/pkg/message"
 )
 
-// For nodes, key is [router-id+name]
+// For nodes, key is [router-id+Asn+Lsid], as per sections 3.2.1.1 and 3.2.1.4 of RFC7752,
+// We do not use name as part of the key since it is optional as per https://datatracker.ietf.org/doc/html/rfc7752#section-3.3.1.3
 type nodeKey struct {
 	IGPRouterId string
-	Name        string
+	Asn         uint32
+	Lsid        uint32
 }
 
 // For links, key is [router-id, local-link IP, remote-link IP]
@@ -70,15 +72,14 @@ func (s *BGPLSStore) UpdateNode(node *message.LSNode) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// Check for empty strings
-	// TBD struggling to add node name with gobgp 3.37
-	//	if node.IGPRouterID == "" || node.Name == "" {
-	if node.IGPRouterID == "" && node.Name == "" {
-		return fmt.Errorf("empty string not expected in [%s, %s] part of <%+v>", node.IGPRouterID, node.Name, node)
+	// Check for empty values
+	if node.IGPRouterID == "" || node.LSID == 0 || node.ASN == 0 {
+		return fmt.Errorf("empty values not expected in <%+v>", node)
 	}
 	key := nodeKey{
 		IGPRouterId: node.IGPRouterID,
-		Name:        node.Name,
+		Asn:         node.ASN,
+		Lsid:        node.LSID,
 	}
 	switch node.Action {
 	case "add":

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -35,11 +35,44 @@ func TestUpdateLinkErrorUnsupportedAction(t *testing.T) {
 	checkStoreContentLengths(t, s, 0, 0)
 }
 
-func TestUpdateNodeErrorEmptyString(t *testing.T) {
+func TestUpdateNodeErrorEmpty(t *testing.T) {
 	s := store.NewBGPLSStore()
 
 	err := s.UpdateNode(&message.LSNode{Action: "add"})
-	require.NotNil(t, err)
+	require.ErrorContains(t, err, "empty values not expected")
+
+	checkStoreContentLengths(t, s, 0, 0)
+}
+
+func TestUpdateNodeErrorNoRouterid(t *testing.T) {
+	s := store.NewBGPLSStore()
+
+	err := s.UpdateNode(&message.LSNode{Action: "add",
+		ASN:  117,
+		LSID: 2000})
+	require.ErrorContains(t, err, "empty values not expected")
+
+	checkStoreContentLengths(t, s, 0, 0)
+}
+
+func TestUpdateNodeErrorNoAsn(t *testing.T) {
+	s := store.NewBGPLSStore()
+
+	err := s.UpdateNode(&message.LSNode{Action: "add",
+		IGPRouterID: "abcd",
+		LSID:        2000})
+	require.ErrorContains(t, err, "empty values not expected")
+
+	checkStoreContentLengths(t, s, 0, 0)
+}
+
+func TestUpdateNodeErrorNoLsid(t *testing.T) {
+	s := store.NewBGPLSStore()
+
+	err := s.UpdateNode(&message.LSNode{Action: "add",
+		ASN:         117,
+		IGPRouterID: "abcd"})
+	require.ErrorContains(t, err, "empty values not expected")
 
 	checkStoreContentLengths(t, s, 0, 0)
 }
@@ -49,7 +82,8 @@ func TestUpdateNodeErrorUnsupportedAction(t *testing.T) {
 
 	err := s.UpdateNode(&message.LSNode{Action: "",
 		IGPRouterID: "abcd",
-		Name:        "nodename"})
+		LSID:        2000,
+		ASN:         786})
 	require.NotNil(t, err)
 
 	checkStoreContentLengths(t, s, 0, 0)
@@ -87,13 +121,14 @@ func TestNode(t *testing.T) {
 	node := message.LSNode{
 		Action:      "add",
 		IGPRouterID: "abcd",
-		Name:        "node"}
+		LSID:        1000,
+		ASN:         786}
 	err := s.UpdateNode(&node)
 	require.Nil(t, err)
 	// 1 node expected
 	checkStoreContentLengths(t, s, 0, 1)
 
-	// Add the same link
+	// Add the same node again
 	err = s.UpdateNode(&node)
 	require.Nil(t, err)
 	// 1 node expected


### PR DESCRIPTION
The node name is optional. e.g. GoBGP sets it in the route advertisement but doesn't set it in the withdraw message. Because of this node removal was failing in the "store".