### PR TITLE
[NMOD-7758] Accept BGP-LS id = 0 when storing BGP-LS node

### DIFF
--- a/pkg/store/bgpls.go
+++ b/pkg/store/bgpls.go
@@ -73,7 +73,7 @@ func (s *BGPLSStore) UpdateNode(node *message.LSNode) error {
 	defer s.mutex.Unlock()
 
 	// Check for empty values
-	if node.IGPRouterID == "" || node.LSID == 0 || node.ASN == 0 {
+	if node.IGPRouterID == "" || node.ASN == 0 {
 		return fmt.Errorf("empty values not expected in <%+v>", node)
 	}
 	key := nodeKey{

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -66,15 +66,16 @@ func TestUpdateNodeErrorNoAsn(t *testing.T) {
 	checkStoreContentLengths(t, s, 0, 0)
 }
 
-func TestUpdateNodeErrorNoLsid(t *testing.T) {
+func TestUpdateNodeNoLsid(t *testing.T) {
 	s := store.NewBGPLSStore()
 
+	// By default LSID would be 0 and this is valid
 	err := s.UpdateNode(&message.LSNode{Action: "add",
 		ASN:         117,
 		IGPRouterID: "abcd"})
-	require.ErrorContains(t, err, "empty values not expected")
+	require.Nil(t, err)
 
-	checkStoreContentLengths(t, s, 0, 0)
+	checkStoreContentLengths(t, s, 0, 1)
 }
 
 func TestUpdateNodeErrorUnsupportedAction(t *testing.T) {


### PR DESCRIPTION
While doing IT in lab+UAT for GoBMP, I noticed that we are getting BGP-LS id of 0 which the fix for NMOD-7673 discards because it thinks it’s invalid. However while a value of 0 is not recommended, it is not prohibited.

Tested in UT and IT (UAT env).