### PR TITLE
Add Kafka SASL auth and configuration though environment vars

### DIFF
--- a/cmd/gobmp/gobmp.go
+++ b/cmd/gobmp/gobmp.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 
-	"net/http"
 	_ "net/http/pprof"
 
 	"github.com/golang/glog"
@@ -26,32 +26,54 @@ import (
 )
 
 var (
-	dstPort           int
-	srcPort           int
-	perfPort          int
-	kafkaSrv          string
-	kafkaTpRetnTimeMs string // Kafka topic retention time in ms
-	natsSrv           string
-	intercept         string
-	splitAF           string
-	dump              string
-	file              string
-	storeData         string
+	dstPort            int
+	srcPort            int
+	perfPort           int
+	kafkaSrv           string
+	kafkaTpRetnTimeMs  string // Kafka topic retention time in ms
+	natsSrv            string
+	intercept          string
+	splitAF            string
+	dump               string
+	file               string
+	storeData          string
+	kafkaSASLEnable    bool
+	kafkaSASLMechanism string
+	kafkaSASLUsername  string
+	kafkaSASLPassword  string
 )
 
 func init() {
 	runtime.GOMAXPROCS(1)
-	flag.IntVar(&srcPort, "source-port", 5000, "port exposed to outside")
-	flag.IntVar(&dstPort, "destination-port", 5050, "port openBMP is listening")
-	flag.StringVar(&kafkaSrv, "kafka-server", "", "URL to access Kafka server")
-	flag.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", "900000", "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
-	flag.StringVar(&natsSrv, "nats-server", "", "URL to access NATS server")
-	flag.StringVar(&intercept, "intercept", "false", "When intercept set \"true\", all incomming BMP messges will be copied to TCP port specified by destination-port, otherwise received BMP messages will be published to Kafka.")
-	flag.StringVar(&splitAF, "split-af", "true", "When set \"true\" (default) ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
-	flag.IntVar(&perfPort, "performance-port", 56767, "port used for performance debugging")
-	flag.StringVar(&dump, "dump", "", "Dump resulting messages to file when \"dump=file\", to standard output when \"dump=console\" or to NATS when \"dump=nats\"")
-	flag.StringVar(&file, "msg-file", "/tmp/messages.json", "Full path anf file name to store messages when \"dump=file\"")
-	flag.StringVar(&storeData, "store-data", "false", "When store-data is set to \"true\", the supported (BGP-LS only for now) BMP state will be stored and accesible through API")
+	// Set defaults
+	srcPort = 5000
+	dstPort = 5050
+	kafkaTpRetnTimeMs = "900000"
+	intercept = "false"
+	splitAF = "true"
+	perfPort = 56767
+	file = "/tmp/messages.json"
+	kafkaSASLEnable = false
+	storeData = "false"
+
+	applyEnvOverrides()
+
+	// Flags (CLI overrides env/defaults)
+	flag.IntVar(&srcPort, "source-port", srcPort, "port exposed to outside")
+	flag.IntVar(&dstPort, "destination-port", dstPort, "port openBMP is listening")
+	flag.StringVar(&kafkaSrv, "kafka-server", kafkaSrv, "URL to access Kafka server")
+	flag.StringVar(&kafkaTpRetnTimeMs, "kafka-topic-retention-time-ms", kafkaTpRetnTimeMs, "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
+	flag.StringVar(&natsSrv, "nats-server", natsSrv, "URL to access NATS server")
+	flag.StringVar(&intercept, "intercept", intercept, "When intercept set \"true\", all incomming BMP messges will be copied to TCP port specified by destination-port, otherwise received BMP messages will be published to Kafka.")
+	flag.StringVar(&splitAF, "split-af", splitAF, "When set \"true\" (default) ipv4 and ipv6 will be published in separate topics. if set \"false\" the same topic will be used for both address families.")
+	flag.IntVar(&perfPort, "performance-port", perfPort, "port used for performance debugging")
+	flag.StringVar(&dump, "dump", dump, "Dump resulting messages to file when \"dump=file\", to standard output when \"dump=console\" or to NATS when \"dump=nats\"")
+	flag.StringVar(&file, "msg-file", file, "Full path anf file name to store messages when \"dump=file\"")
+	flag.BoolVar(&kafkaSASLEnable, "kafka-sasl-enable", kafkaSASLEnable, "Enable SASL authentication for Kafka producer")
+	flag.StringVar(&kafkaSASLMechanism, "kafka-sasl-mechanism", kafkaSASLMechanism, "SASL mechanism for Kafka producer (e.g., PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)")
+	flag.StringVar(&kafkaSASLUsername, "kafka-sasl-username", kafkaSASLUsername, "SASL username for Kafka producer")
+	flag.StringVar(&kafkaSASLPassword, "kafka-sasl-password", kafkaSASLPassword, "SASL password for Kafka producer")
+	flag.StringVar(&storeData, "store-data", storeData, "When store-data is set to \"true\", the supported (BGP-LS only for now) BMP state will be stored and accesible through API")
 }
 
 func main() {
@@ -90,6 +112,10 @@ func main() {
 		kConfig := &kafka.Config{
 			ServerAddress:        kafkaSrv,
 			TopicRetentionTimeMs: kafkaTpRetnTimeMs,
+			SASLEnable:           kafkaSASLEnable,
+			SASLMechanism:        kafkaSASLMechanism,
+			SASLUsername:         kafkaSASLUsername,
+			SASLPassword:         kafkaSASLPassword,
 		}
 		publisher, err = kafka.NewKafkaPublisher(kConfig)
 		if err != nil {
@@ -154,4 +180,56 @@ func registerGRPCStoreServices(s *grpc.Server, bmpsrv gobmpsrv.BMPServer) error 
 	generated.RegisterStoreContentsServiceServer(s, storeContentsServer)
 
 	return nil
+}
+
+// applyEnvOverrides sets global config variables from environment variables if present.
+func applyEnvOverrides() {
+	if val := os.Getenv("GOBMP_SOURCE_PORT"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			srcPort = v
+		}
+	}
+	if val := os.Getenv("GOBMP_DESTINATION_PORT"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			dstPort = v
+		}
+	}
+	if val := os.Getenv("GOBMP_KAFKA_SERVER"); val != "" {
+		kafkaSrv = val
+	}
+	if val := os.Getenv("GOBMP_KAFKA_TOPIC_RETENTION_TIME_MS"); val != "" {
+		kafkaTpRetnTimeMs = val
+	}
+	if val := os.Getenv("GOBMP_NATS_SERVER"); val != "" {
+		natsSrv = val
+	}
+	if val := os.Getenv("GOBMP_INTERCEPT"); val != "" {
+		intercept = val
+	}
+	if val := os.Getenv("GOBMP_SPLIT_AF"); val != "" {
+		splitAF = val
+	}
+	if val := os.Getenv("GOBMP_PERFORMANCE_PORT"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			perfPort = v
+		}
+	}
+	if val := os.Getenv("GOBMP_DUMP"); val != "" {
+		dump = val
+	}
+	if val := os.Getenv("GOBMP_MSG_FILE"); val != "" {
+		file = val
+	}
+	if val := os.Getenv("GOBMP_KAFKA_SASL_ENABLE"); val != "" {
+		kafkaSASLEnable = val == "true" || val == "1"
+	}
+	if val := os.Getenv("GOBMP_KAFKA_SASL_MECHANISM"); val != "" {
+		kafkaSASLMechanism = val
+	}
+	if val := os.Getenv("GOBMP_KAFKA_SASL_USERNAME"); val != "" {
+		kafkaSASLUsername = val
+	}
+	if val := os.Getenv("GOBMP_KAFKA_SASL_PASSWORD"); val != "" {
+		kafkaSASLPassword = val
+	}
 }

--- a/cmd/player/player.go
+++ b/cmd/player/player.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -18,19 +19,54 @@ import (
 )
 
 var (
-	msgSrvAddr string
+	msgSrvAddr      string
 	topicRetnTimeMs string
-	file       string
-	delay      int
-	iterations int
+	file            string
+	delay           int
+	iterations      int
 )
 
 func init() {
-	flag.StringVar(&msgSrvAddr, "message-server", "", "URL to the messages supplying server")
-	flag.StringVar(&topicRetnTimeMs, "topic-retention-time-ms", "900000", "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
-	flag.StringVar(&file, "msg-file", "/tmp/messages.json", "File with the bmp messages to replay")
-	flag.IntVar(&delay, "delay", 0, "Delay in seconds to add between sending messages")
-	flag.IntVar(&iterations, "iterations", 1, "Number of iterations to replay messages")
+	// Set defaults
+	msgSrvAddrDefault := ""
+	topicRetnTimeMsDefault := "900000"
+	fileDefault := "/tmp/messages.json"
+	delayDefault := 0
+	iterationsDefault := 1
+
+	// Start with defaults
+	msgSrvAddr = msgSrvAddrDefault
+	topicRetnTimeMs = topicRetnTimeMsDefault
+	file = fileDefault
+	delay = delayDefault
+	iterations = iterationsDefault
+
+	// Environment variable overrides
+	if val := os.Getenv("GOBMP_MESSAGE_SERVER"); val != "" {
+		msgSrvAddr = val
+	}
+	if val := os.Getenv("GOBMP_TOPIC_RETENTION_TIME_MS"); val != "" {
+		topicRetnTimeMs = val
+	}
+	if val := os.Getenv("GOBMP_MSG_FILE"); val != "" {
+		file = val
+	}
+	if val := os.Getenv("GOBMP_DELAY"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			delay = v
+		}
+	}
+	if val := os.Getenv("GOBMP_ITERATIONS"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			iterations = v
+		}
+	}
+	// Flags (CLI overrides env/defaults)
+	flag.StringVar(&msgSrvAddr, "message-server", msgSrvAddr, "URL to the messages supplying server")
+	flag.StringVar(&topicRetnTimeMs, "topic-retention-time-ms", topicRetnTimeMs, "Kafka topic retention time in ms, default is 900000 ms i.e 15 minutes")
+	flag.StringVar(&file, "msg-file", file, "File with the bmp messages to replay")
+	flag.IntVar(&delay, "delay", delay, "Delay in seconds to add between sending messages")
+	flag.IntVar(&iterations, "iterations", iterations, "Number of iterations to replay messages")
 }
 
 func main() {
@@ -46,7 +82,7 @@ func main() {
 
 	// Initializing publisher process
 	kConfig := &kafka.Config{
-		ServerAddress: msgSrvAddr,
+		ServerAddress:        msgSrvAddr,
 		TopicRetentionTimeMs: topicRetnTimeMs,
 	}
 	publisher, err := kafka.NewKafkaPublisher(kConfig)
@@ -82,7 +118,7 @@ func main() {
 		glog.Infof("%3f seconds took to process %d records", time.Since(start).Seconds(), records)
 		records = 0
 	}
-    _ = f.Close()
+	_ = f.Close()
 
 	os.Exit(0)
 }

--- a/cmd/validator/validator.go
+++ b/cmd/validator/validator.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,11 +23,44 @@ var (
 )
 
 func init() {
-	flag.StringVar(&msgSrvAddr, "kafka", "kafka:9092", "kafka server url, default: kafka:9092")
-	flag.StringVar(&msgFile, "msg-file", "./messages.json", "file to read from or to store to processed bmp messages")
-	flag.IntVar(&timeout, "timeout", 300, "timeout in seconds, default 300, for the test to complete all processing.")
-	flag.BoolVar(&validatorFlag, "validate", false, "when validator is true, incomming messages are validated against stored in the message file, otherwise the messages are stored in the file.")
-	flag.StringVar(&testCase, "test-case", "u4", "test case to validate or to collect messages")
+	// Set defaults
+	msgSrvAddrDefault := "kafka:9092"
+	msgFileDefault := "./messages.json"
+	timeoutDefault := 300
+	validatorFlagDefault := false
+	testCaseDefault := "u4"
+
+	// Start with defaults
+	msgSrvAddr = msgSrvAddrDefault
+	msgFile = msgFileDefault
+	timeout = timeoutDefault
+	validatorFlag = validatorFlagDefault
+	testCase = testCaseDefault
+
+	// Environment variable overrides
+	if val := os.Getenv("GOBMP_KAFKA"); val != "" {
+		msgSrvAddr = val
+	}
+	if val := os.Getenv("GOBMP_MSG_FILE"); val != "" {
+		msgFile = val
+	}
+	if val := os.Getenv("GOBMP_TIMEOUT"); val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			timeout = v
+		}
+	}
+	if val := os.Getenv("GOBMP_VALIDATE"); val != "" {
+		validatorFlag = val == "true" || val == "1"
+	}
+	if val := os.Getenv("GOBMP_TEST_CASE"); val != "" {
+		testCase = val
+	}
+	// Flags (CLI overrides env/defaults)
+	flag.StringVar(&msgSrvAddr, "kafka", msgSrvAddr, "kafka server url, default: kafka:9092")
+	flag.StringVar(&msgFile, "msg-file", msgFile, "file to read from or to store to processed bmp messages")
+	flag.IntVar(&timeout, "timeout", timeout, "timeout in seconds, default 300, for the test to complete all processing.")
+	flag.BoolVar(&validatorFlag, "validate", validatorFlag, "when validator is true, incomming messages are validated against stored in the message file, otherwise the messages are stored in the file.")
+	flag.StringVar(&testCase, "test-case", testCase, "test case to validate or to collect messages")
 }
 
 func main() {

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -3,4 +3,8 @@ package kafka
 type Config struct {
 	ServerAddress        string
 	TopicRetentionTimeMs string
+	SASLEnable           bool
+	SASLMechanism        string
+	SASLUsername         string
+	SASLPassword         string
 }

--- a/pkg/kafka/kafka-publisher.go
+++ b/pkg/kafka/kafka-publisher.go
@@ -44,31 +44,31 @@ var (
 	topicCreateTimeout    = 1 * time.Second
 )
 
-var (
-	// topics defines a list of topic to initialize and connect,
-	// initialization is done as a part of NewKafkaPublisher func.
-	topicNames = []string{
-		PeerTopic,
-		UnicastMessageTopic,
-		UnicastMessageV4Topic,
-		UnicastMessageV6Topic,
-		LSNodeMessageTopic,
-		LSLinkMessageTopic,
-		L3vpnMessageTopic,
-		L3vpnMessageV4Topic,
-		L3vpnMessageV6Topic,
-		LSPrefixMessageTopic,
-		LSSRv6SIDMessageTopic,
-		EVPNMessageTopic,
-		SRPolicyMessageTopic,
-		SRPolicyMessageV4Topic,
-		SRPolicyMessageV6Topic,
-		FlowspecMessageTopic,
-		FlowspecMessageV4Topic,
-		FlowspecMessageV6Topic,
-		StatsMessageTopic,
-	}
-)
+// topics defines a list of topic to initialize and connect,
+// initialization is done as a part of NewKafkaPublisher func.
+var topicNames = []string{
+	PeerTopic,
+	UnicastMessageTopic,
+	UnicastMessageV4Topic,
+	UnicastMessageV6Topic,
+	LSNodeMessageTopic,
+	LSLinkMessageTopic,
+	L3vpnMessageTopic,
+	L3vpnMessageV4Topic,
+	L3vpnMessageV6Topic,
+	LSPrefixMessageTopic,
+	LSSRv6SIDMessageTopic,
+	EVPNMessageTopic,
+	SRPolicyMessageTopic,
+	SRPolicyMessageV4Topic,
+	SRPolicyMessageV6Topic,
+	FlowspecMessageTopic,
+	FlowspecMessageV4Topic,
+	FlowspecMessageV6Topic,
+	StatsMessageTopic,
+}
+
+// SCRAM support removed; SASL/PLAIN only
 
 type publisher struct {
 	broker   *sarama.Broker
@@ -157,6 +157,15 @@ func NewKafkaPublisher(kConfig *Config) (pub.Publisher, error) {
 	config.Producer.Return.Errors = true
 	config.Admin.Retry.Max = 100
 	config.Version = sarama.V1_1_0_0
+
+	// SASL authentication support
+	if kConfig.SASLEnable {
+		config.Net.SASL.Enable = true
+		config.Net.SASL.User = kConfig.SASLUsername
+		config.Net.SASL.Password = kConfig.SASLPassword
+		// Only SASL/PLAIN is supported
+		config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+	}
 
 	br := sarama.NewBroker(kConfig.ServerAddress)
 
@@ -300,5 +309,4 @@ func waitForBrokerConnection(br *sarama.Broker, config *sarama.Config, timeout t
 			return fmt.Errorf("timeout waiting for the connection to the broker %s", br.Addr())
 		}
 	}
-
 }


### PR DESCRIPTION
This PR adds SASL authentication (currentl PLAINTEXT only) to the GoBMP Kafka Producer.
Also, command line arguments are now available as environment variables